### PR TITLE
factories: use a custom factory to return proper JSON

### DIFF
--- a/factories/api_student.rb
+++ b/factories/api_student.rb
@@ -4,5 +4,11 @@ require "faker"
 
 Faker::Config.locale = :fr
 
+FactoryBot.define do
+  factory :json_factory, class: "Hash" do
+    initialize_with { attributes.as_json }
+  end
+end
+
 require_relative "sygne"
 require_relative "fregata"

--- a/factories/fregata.rb
+++ b/factories/fregata.rb
@@ -8,7 +8,7 @@ require "ostruct"
 
 # rubocop:disable Metrics/BlockLength
 FactoryBot.define do
-  factory :fregata_student, class: OpenStruct do # rubocop:disable Style/OpenStructUse
+  factory :fregata_student, parent: :json_factory do
     id { Faker::Number.number }
     dateSortieEtablissement { left_at }
     dateSortieFormation { left_classe_at }

--- a/factories/sygne.rb
+++ b/factories/sygne.rb
@@ -9,7 +9,7 @@ require "ostruct"
 Faker::Config.locale = :fr
 
 FactoryBot.define do
-  factory :sygne_student, class: OpenStruct do # rubocop:disable Style/OpenStructUse
+  factory :sygne_student, parent: :json_factory do
     ine { Faker::Alphanumeric.alphanumeric(number: 10).upcase }
     prenom { Faker::Name.first_name }
     nom { Faker::Name.last_name }
@@ -33,7 +33,7 @@ FactoryBot.define do
 end
 
 FactoryBot.define do
-  factory :sygne_student_info, class: OpenStruct do # rubocop:disable Style/OpenStructUse
+  factory :sygne_student_info, parent: :json_factory do
     ine { Faker::Alphanumeric.alphanumeric(number: 10).upcase }
     prenom1 { Faker::Name.first_name }
     prenom2 { Faker::Name.first_name }


### PR DESCRIPTION
We were using OpenStruct which exports with symbolised keys, and that's no good. We're expecting JSON from the API so make a JSON factory that uses a custom initializer to export itself as a proper-parsed JSON hash.