### PR TITLE
factory: use a shared student API to factor our common values

### DIFF
--- a/factories/api_student.rb
+++ b/factories/api_student.rb
@@ -9,6 +9,27 @@ FactoryBot.define do
   factory :json_factory, class: "Hash" do
     initialize_with { JSON.parse(attributes.to_json) }
   end
+
+  factory :api_student, parent: :json_factory do
+    transient do
+      ine_value { Faker::Alphanumeric.alphanumeric(number: 10).upcase }
+      first_name { Faker::Name.first_name }
+      last_name { Faker::Name.last_name }
+      birthdate { Faker::Date.between(from: 20.years.ago, to: 16.years.ago).to_s }
+      address_line1 { Faker::Address.street_name }
+      address_line2 { Faker::Address.street_name }
+      address_postal_code { Faker::Address.zip_code }
+      address_city { Faker::Address.city }
+      address_city_insee_code { Faker::Number.number(digits: 5).to_s }
+      address_country_code { Faker::Number.number(digits: 5).to_s }
+      birthplace_city_insee_code { Faker::Number.number(digits: 5).to_s }
+      birthplace_country_insee_code { Faker::Number.number(digits: 5).to_s }
+    end
+
+    trait :no_ine do
+      ine_value { nil }
+    end
+  end
 end
 
 require_relative "sygne"

--- a/factories/fregata.rb
+++ b/factories/fregata.rb
@@ -8,7 +8,7 @@ require "ostruct"
 
 # rubocop:disable Metrics/BlockLength
 FactoryBot.define do
-  factory :fregata_student, parent: :json_factory do
+  factory :fregata_student, parent: :api_student do
     id { Faker::Number.number }
     dateSortieEtablissement { left_at&.to_date }
     dateSortieFormation { left_classe_at&.to_date }
@@ -25,13 +25,13 @@ FactoryBot.define do
     end
     apprenant do
       {
-        "prenomUsuel" => Faker::Name.first_name,
-        "nomUsuel" => Faker::Name.last_name,
-        "dateNaissance" => Faker::Date.between(from: 20.years.ago, to: 16.years.ago).to_s,
-        "ine" => ine,
+        "prenomUsuel" => first_name,
+        "nomUsuel" => last_name,
+        "dateNaissance" => birthdate,
+        "ine" => ine_value,
         "adressesApprenant" => adressesApprenant,
-        "communeCodeInsee" => "34000",
-        "paysCodeInsee" => "99100"
+        "communeCodeInsee" => birthplace_city_insee_code,
+        "paysCodeInsee" => birthplace_country_insee_code
       }
     end
 
@@ -59,15 +59,9 @@ FactoryBot.define do
       end
     end
 
-    trait :no_ine do
-      ine { nil }
-    end
-
     transient do
       left_at { nil }
       left_classe_at { nil }
-
-      ine { Faker::Number.number(digits: 10).to_s }
 
       classe_label do
         [
@@ -83,15 +77,15 @@ FactoryBot.define do
           {
             "estPrioritaire" => true,
             "adresseIndividu" => {
-              "ligne2" => "80 RUE DU TEST",
-              "ligne3" => nil,
+              "ligne2" => address_line1,
+              "ligne3" => address_line2,
               "ligne4" => nil,
               "ligne5" => nil,
               "ligne6" => "34080 MONTPELLIER",
               "ligne7" => "FRANCE",
-              "communeCodePostal" => "34080",
-              "communeCodeInsee" => "34172",
-              "paysCodeInsee" => "99100"
+              "communeCodePostal" => address_postal_code,
+              "communeCodeInsee" => address_city_insee_code,
+              "paysCodeInsee" => address_country_code
             }
           }
         ]

--- a/factories/sygne.rb
+++ b/factories/sygne.rb
@@ -6,14 +6,13 @@ require "factory_bot"
 require "faker"
 require "ostruct"
 
-# rubocop:disable Metrics/BlockLength
 FactoryBot.define do
-  factory :sygne_student, parent: :json_factory do
-    ine { Faker::Alphanumeric.alphanumeric(number: 10).upcase }
-    prenom { Faker::Name.first_name }
-    nom { Faker::Name.last_name }
-    dateNaissance { Faker::Date.between(from: 20.years.ago, to: 16.years.ago).to_s }
-    codeSexe { [0, 1].sample }
+  factory :sygne_student, parent: :api_student do
+    ine { ine_value }
+    prenom { first_name }
+    nom { last_name }
+    dateNaissance { birthdate }
+    codeSexe { biological_sex }
     niveau { "2212" }
     codeMef { "24720008ABC" }
     codeMefRatt { mef }
@@ -30,10 +29,6 @@ FactoryBot.define do
       classe { "NOUVELLE CLASSE #{rand}" }
     end
 
-    trait :no_ine do
-      ine { nil }
-    end
-
     transient do
       mef { "24720008310" }
     end
@@ -45,27 +40,26 @@ FactoryBot.define do
 end
 
 FactoryBot.define do
-  factory :sygne_student_info, parent: :json_factory do
-    ine { Faker::Alphanumeric.alphanumeric(number: 10).upcase }
-    prenom1 { Faker::Name.first_name }
+  factory :sygne_student_info, parent: :api_student do
+    ine { ine_value }
+    prenom1 { first_name }
     prenom2 { Faker::Name.first_name }
     prenom3 { Faker::Name.first_name }
-    nomUsage { Faker::Name.last_name }
-    dateNaissance { Faker::Date.between(from: 20.years.ago, to: 16.years.ago).to_s }
+    nomUsage { last_name }
+    dateNaissance { birthdate }
     adrResidenceEle do
       {
-        "adresseLigne1" => Faker::Address.street_name,
-        "adresseLigne2" => Faker::Address.street_name,
+        "adresseLigne1" => address_line1,
+        "adresseLigne2" => address_line2,
         "adresseLigne3" => Faker::Address.street_name,
         "adresseLigne4" => Faker::Address.street_name,
-        "codePostal" => Faker::Address.zip_code,
-        "libelleCommune" => Faker::Address.city,
-        "codeCommuneInsee" => Faker::Number.number(digits: 4).to_s,
-        "codePays" => Faker::Number.number(digits: 3).to_s
+        "codePostal" => address_postal_code,
+        "libelleCommune" => address_city,
+        "codeCommuneInsee" => address_city_insee_code,
+        "codePays" => address_country_code
       }
     end
-    inseeCommuneNaissance { "123" }
-    inseePaysNaissance { "456" }
+    inseeCommuneNaissance { birthplace_city_insee_code }
+    inseePaysNaissance { birthplace_country_insee_code }
   end
 end
-# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Since we try and maintain factory-replicas of the respective student APIs, it makes sense to have a common factory that defines "how we refer to things" and have two inheriting factories that know "how the API refers to it". This should help factor our some code and make maintenance easier.