### PR TITLE
Disable middleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN bundle install
 WORKDIR /app
 COPY . .
 
-CMD ["ruby", "server.rb"]
+CMD ["rackup", "-p", "3002", "-o", "0.0.0.0"]

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,18 @@
+require 'rack'
+require 'rack/protection'
+
+# NOTE: Bypass Host Auth because we dont need it
+# (using Sinatra options seemingly didnt work)
+module Rack
+  module Protection
+    class HostAuthorization
+      def call(env)
+        @app.call(env)
+      end
+    end
+  end
+end
+
+require './server'
+
+run Sinatra::Application


### PR DESCRIPTION
We dont need it because the mock is only used locally.